### PR TITLE
Fix script CRLF output and add frictionless validate to CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,13 +38,18 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
-          pip install -r scripts/requirements.txt
+          pip install -r scripts/requirements.txt frictionless
 
     - name: Run scripts
       run: |
         source venv/bin/activate
         ./scripts/process.sh
         python scripts/bond_us_flow.py
+
+    - name: Validate datapackage
+      run: |
+        source venv/bin/activate
+        frictionless validate datapackage.json
 
     - name: Configure Git
       run: |

--- a/scripts/process.sh
+++ b/scripts/process.sh
@@ -1,4 +1,4 @@
-curl -L "http://www.federalreserve.gov/datadownload/Output.aspx?rel=H15&series=0809abf197c17f1ff0b2180fe7015cc3&lastObs=&from=&to=&filetype=csv&label=include&layout=seriescolumn" > archive/h15-m.csv
+curl -L "http://www.federalreserve.gov/datadownload/Output.aspx?rel=H15&series=0809abf197c17f1ff0b2180fe7015cc3&lastObs=&from=&to=&filetype=csv&label=include&layout=seriescolumn" | tr -d '\r' > archive/h15-m.csv
 
 echo "Date,Rate" > data/monthly.csv
 cat archive/h15-m.csv | tail -n+7 | sed "s/^\(.......\)/\1-01/" >> data/monthly.csv


### PR DESCRIPTION
## Problem
`scripts/process.sh` piped curl output (which contains CRLF line endings from the Federal Reserve server) directly into `archive/h15-m.csv` and `data/monthly.csv`, causing all data files to have CRLF line endings.

The CI workflow had no `frictionless validate` step, allowing descriptor/data drift to go undetected.

## Changes
- Added `tr -d '\r'` to `process.sh` so future data regenerations produce LF-only CSV files
- Added `frictionless validate datapackage.json` step to CI (installed via pip alongside existing dependencies); the step fails the workflow on validation errors, preventing descriptor/data drift from being merged undetected